### PR TITLE
Fix for infinite show/hide loop with short-lived popups and push

### DIFF
--- a/src/com/github/wolfie/popupextension/PopupExtension.java
+++ b/src/com/github/wolfie/popupextension/PopupExtension.java
@@ -48,7 +48,7 @@ public class PopupExtension extends AbstractExtension {
 
 			@Override
 			public void setOpen(final boolean open) {
-				if (open != getState().open) {
+				if (open != getState().open && getState().closeOnOutsideMouseClick) {
 					getState().open = open;
 					fireVisibilityListeners();
 				}


### PR DESCRIPTION
For short-lived popups that are closed via push, the call-back from the visibility change on the client side can lead to a loop where the popup is toggling its visibility forever.

For popups that cannot be closed by clicking on the outside, the client-side visibility change does not do anything useful, since the listeners are notified from the server side change.This fix ignores that client-side RPC call for that condition and prevents the loop from occurring.
